### PR TITLE
Fix stream-overflow bug and add parenthesized expression test

### DIFF
--- a/parser/RecursiveDescentParser.cpp
+++ b/parser/RecursiveDescentParser.cpp
@@ -16,7 +16,8 @@ std::map<char, int> kaleido::parser::RecursiveDescentParser::OPERATOR_PRECEDENCE
     {'<', 1},
     {'+', 2},
     {'-', 2},
-    {'*', 4}
+    {'*', 4},
+    {'/', 4}
 };
 std::unique_ptr<TreeNode> kaleido::parser::RecursiveDescentParser::parse() {
 
@@ -111,6 +112,9 @@ int kaleido::parser::RecursiveDescentParser::getPrecedence(const Token &token) {
 std::unique_ptr<TreeNode> kaleido::parser::RecursiveDescentParser::parseBinaryOperationRhs(int minPrecedence,
                                                                                            std::unique_ptr<TreeNode> lhs) {
     while (true) {
+        if (mCurrentTokenIndex >= mTokenStream.size()) {
+            return lhs;
+        }
         auto tokenPrecedence = getPrecedence(getCurrentToken());
         if (tokenPrecedence < minPrecedence) {
             return lhs;
@@ -122,7 +126,10 @@ std::unique_ptr<TreeNode> kaleido::parser::RecursiveDescentParser::parseBinaryOp
             return nullptr;
         }
         // peek into next and decide how to group operators
-        auto nextTokenPrecedence = getPrecedence(getCurrentToken());
+        auto nextTokenPrecedence = -1;
+        if (mCurrentTokenIndex < mTokenStream.size()) {
+            nextTokenPrecedence = getPrecedence(getCurrentToken());
+        }
         if (tokenPrecedence < nextTokenPrecedence) {
             rhs = parseBinaryOperationRhs(tokenPrecedence + 1, std::move(rhs));
             if (rhs == nullptr) {

--- a/tests/RecursiveDescentParserTest.cpp
+++ b/tests/RecursiveDescentParserTest.cpp
@@ -5,6 +5,7 @@
 #include "utils/PointerUtils.h"
 #include <gtest/gtest.h>
 #include "parser/ast/Multiplication.h"
+#include "parser/ast/Division.h"
 using namespace kaleido::parser;
 using namespace kaleido;
 using namespace kaleido::ast;
@@ -23,4 +24,11 @@ TEST(RecursiveDescentParserTest, TopLevelExpressions) {
     const auto &shouldBe5 = dynamic_cast<const Literal &>(rhs.rightChild());
     EXPECT_EQ(shouldBe4.value(), 4);
     EXPECT_EQ(shouldBe5.value(), 5);
+}
+TEST(RecursiveDescentParserTest, ParenthesesExpressions) {
+    std::istringstream istream("( 3 + ( 5 / 6 ) )");
+    std::unique_ptr<Lexer> toPass = std::make_unique<RegexLexer>(istream);
+    RecursiveDescentParser parser(std::move(toPass));
+    auto result = dynamic_cast<Function *>(parser.parseTopLevelExpression().release());
+    const auto &expression = dynamic_cast<const BinaryExpression &>(result->body());
 }


### PR DESCRIPTION
There existed a bug wherein `RecursiveDescentParser::mCurrentTokenIndex` would exceed the `mTokenStream.size` causing a `SIGSEGV` to be sent. This PR fixes this bug and adds a test for parenthesized expressions.